### PR TITLE
sqlcのドライバーを変更してコースと互換性があるようにする

### DIFF
--- a/sqlc.yaml
+++ b/sqlc.yaml
@@ -4,6 +4,8 @@ sql:
     schema: "./db/migration/"       # スキーマファイル
     queries: "./db/query/"          # クエリファイル
     engine: "postgresql"            # データベースエンジン
+    database:
+      sql_package: "pgx/v5/stdlib"
     gen:
       go:                          # Goの生成設定
         package: "db"


### PR DESCRIPTION
次の講義に移る前に、sqlc.yamlファイルに正しいSQLドライバ（database/sql）が設定されていることを確認してください。

講義が収録された時点では、sqlcの古いバージョン(v1)はまだデフォルトのデータベースドライバとしてdatabase/sqlを使用していたからです。そのため、代わりにpgxドライバを使用する新しいバージョンのsqlc (v2)を使用すると、両者の間に互換性がなくなります。

講義を理解しやすくするために、DBドライバとしてdatabase/sqlを使用する私と同じsqlcの設定を使用することを強くお勧めする。その後、コースのセクション6で、pgxに切り替える方法を説明する新しい講義があります。